### PR TITLE
Connect pre-exam start buttons to Flask

### DIFF
--- a/teraz/exam/pre-exam/10.html
+++ b/teraz/exam/pre-exam/10.html
@@ -512,8 +512,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                        <input type="hidden" name="question_set_id" value="10">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="easy_language_5q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/13c8cf.html
+++ b/teraz/exam/pre-exam/13c8cf.html
@@ -512,9 +512,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                    <input type="hidden" name="from_category" value="true">
-                        <input type="hidden" name="question_set_id" value="13">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="full_nonverbal_15q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/14.html
+++ b/teraz/exam/pre-exam/14.html
@@ -512,8 +512,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                        <input type="hidden" name="question_set_id" value="14">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="easy_nonverbal_5q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/4c8cf.html
+++ b/teraz/exam/pre-exam/4c8cf.html
@@ -512,9 +512,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                    <input type="hidden" name="from_category" value="true">
-                        <input type="hidden" name="question_set_id" value="4">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="full_english_15q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/5.html
+++ b/teraz/exam/pre-exam/5.html
@@ -512,8 +512,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                        <input type="hidden" name="question_set_id" value="5">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="easy_english_5q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/6.html
+++ b/teraz/exam/pre-exam/6.html
@@ -512,8 +512,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                        <input type="hidden" name="question_set_id" value="6">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="easy_english_5q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/8.html
+++ b/teraz/exam/pre-exam/8.html
@@ -512,8 +512,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                        <input type="hidden" name="question_set_id" value="8">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="easy_language_5q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/8c8cf.html
+++ b/teraz/exam/pre-exam/8c8cf.html
@@ -512,9 +512,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                    <input type="hidden" name="from_category" value="true">
-                        <input type="hidden" name="question_set_id" value="8">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="full_language_15q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/9.html
+++ b/teraz/exam/pre-exam/9.html
@@ -512,8 +512,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                        <input type="hidden" name="question_set_id" value="9">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="easy_language_5q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/easy_1000f6.html
+++ b/teraz/exam/pre-exam/easy_1000f6.html
@@ -513,9 +513,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                            <input type="hidden" name="easy_exam" value="true">
-                <input type="hidden" name="question_set_id" value="easy_10">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="easy_language_5q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/easy_1100f6.html
+++ b/teraz/exam/pre-exam/easy_1100f6.html
@@ -513,9 +513,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                            <input type="hidden" name="easy_exam" value="true">
-                <input type="hidden" name="question_set_id" value="easy_11">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="easy_nonverbal_5q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/teraz/exam/pre-exam/easy_1200f6.html
+++ b/teraz/exam/pre-exam/easy_1200f6.html
@@ -513,9 +513,8 @@
         </ul>
     </div>
 
-    <form id="start-exam-form" method="POST" action="https://spi.bakusoku-shukatsu.jp/exam/start">
-        <input type="hidden" name="_token" value="MSJgq0sV0vpxvjW147k43tyVSOduzwYQzuV3Cm0t" autocomplete="off">                            <input type="hidden" name="easy_exam" value="true">
-                <input type="hidden" name="question_set_id" value="easy_12">
+    <form id="start-exam-form" method="POST" action="/exam/start">
+        <input type="hidden" name="question_set_id" value="easy_english_5q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>


### PR DESCRIPTION
## Summary
- Route all pre-exam "start" buttons through `/exam/start`
- Pass question_set_id slugs for each subject/mode combination

## Testing
- `pytest`

## Slug Mapping
| File | question_set_id |
| --- | --- |
| teraz/exam/pre-exam/5.html | easy_english_5q |
| teraz/exam/pre-exam/6.html | easy_english_5q |
| teraz/exam/pre-exam/8.html | easy_language_5q |
| teraz/exam/pre-exam/9.html | easy_language_5q |
| teraz/exam/pre-exam/10.html | easy_language_5q |
| teraz/exam/pre-exam/14.html | easy_nonverbal_5q |
| teraz/exam/pre-exam/easy_1000f6.html | easy_language_5q |
| teraz/exam/pre-exam/easy_1100f6.html | easy_nonverbal_5q |
| teraz/exam/pre-exam/easy_1200f6.html | easy_english_5q |
| teraz/exam/pre-exam/8c8cf.html | full_language_15q |
| teraz/exam/pre-exam/13c8cf.html | full_nonverbal_15q |
| teraz/exam/pre-exam/4c8cf.html | full_english_15q |

------
https://chatgpt.com/codex/tasks/task_e_68b11fe74e888328aeeae5a38853cde4