### PR TITLE
Load easy language 3-question exam

### DIFF
--- a/spi_exam_flask_app/exam/pre-exam/easy_language_3q.html
+++ b/spi_exam_flask_app/exam/pre-exam/easy_language_3q.html
@@ -513,7 +513,7 @@
     </div>
 
     <form id="start-exam-form" method="POST" action="/exam/start">
-        <input type="hidden" name="question_set_id" value="easy_language_5q">
+        <input type="hidden" name="question_set_id" value="easy_language_3q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/spi_exam_flask_app/index.html
+++ b/spi_exam_flask_app/index.html
@@ -636,7 +636,7 @@
                             E. アとウ<br>
                             F. イとウ
                         </div>
-                        <a href="exam/pre-exam/8.html" class="question-button">回答する</a>
+                        <a href="exam/pre-exam/easy_language_3q.html" class="question-button">回答する</a>
                     </div>
 
                     <!-- 問題2 -->


### PR DESCRIPTION
## Summary
- rename pre-exam `8.html` to `easy_language_3q.html`
- load `easy_language_3q.json` when starting the language exam
- update home page link to point to the renamed pre-exam page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3ce2bd14c8328b28a9b236002f02e