### PR TITLE
Rename pre-exam page for ratio nonverbal sample

### DIFF
--- a/spi_exam_flask_app/data/exams/easy/nonverbal/ratio_nonverbal_2q.json
+++ b/spi_exam_flask_app/data/exams/easy/nonverbal/ratio_nonverbal_2q.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "mode": "easy",
+  "category": "nonverbal",
+  "slug": "ratio_nonverbal_2q",
+  "title": "かんたん受験 - 非言語（割合2問）",
+  "description": "割合計算の基礎を確認する2問です。",
+  "time_per_question_sec": 60,
+  "questions": [
+    {
+      "id": "Q1",
+      "type": "mc",
+      "prompt_html": "ある学校で、男子が120人、女子が80人います。全体に占める女子の割合は何%か。必要に応じて、小数点第一位を四捨五入せよ。",
+      "options": ["33%", "40%", "50%", "60%"],
+      "answer_index": 1
+    },
+    {
+      "id": "Q2",
+      "type": "mc",
+      "prompt_html": "ある商品を原価の25%引きで販売したところ、売価は1500円でした。商品の原価はいくらか。",
+      "options": ["1500円", "1800円", "2000円", "2200円"],
+      "answer_index": 2
+    }
+  ]
+}

--- a/spi_exam_flask_app/exam/pre-exam/ratio_nonverbal_2q.html
+++ b/spi_exam_flask_app/exam/pre-exam/ratio_nonverbal_2q.html
@@ -513,7 +513,7 @@
     </div>
 
     <form id="start-exam-form" method="POST" action="/exam/start">
-        <input type="hidden" name="question_set_id" value="easy_nonverbal_5q">
+        <input type="hidden" name="question_set_id" value="ratio_nonverbal_2q">
         <button type="submit" class="start-exam-btn" id="start-exam-btn">
             この内容で受験スタート！
         </button>

--- a/spi_exam_flask_app/index.html
+++ b/spi_exam_flask_app/index.html
@@ -687,7 +687,7 @@
                             C. 36%<br>
                             D. 39%
                         </div>
-                        <a href="exam/pre-exam/14.html" class="question-button">回答する</a>
+                        <a href="exam/pre-exam/ratio_nonverbal_2q.html" class="question-button">回答する</a>
                     </div>
 
                     <!-- 問題5 -->


### PR DESCRIPTION
## Summary
- rename `14.html` to `ratio_nonverbal_2q.html` and use the corresponding question set
- wire index page to the new pre-exam file
- add `ratio_nonverbal_2q.json` to easy nonverbal exam data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3dad295788328865a2b85488f4c72